### PR TITLE
profiler: die with the job

### DIFF
--- a/cylc/flow/remote.py
+++ b/cylc/flow/remote.py
@@ -15,6 +15,7 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """Run command on a remote, (i.e. a remote [user@]host)."""
 
+import asyncio
 import os
 from pathlib import Path
 from posix import WIFSIGNALED
@@ -76,17 +77,38 @@ def get_proc_ancestors():
         pid = ppid
 
 
-def watch_and_kill(proc):
-    """Kill proc if my PPID (etc.) changed - e.g. ssh connection dropped."""
+async def watch_and_kill(proc, interval=None):
+    """Watch a process and kill it if any of its parent processes change.
+
+    Processes exist in a tree which inherits from the process with PID 1.
+
+    If a parent process dies, the child will be re-assigned a new parent.
+    This can happen:
+    * If the parent is killed but the signal is not propagated to its children
+      (or is caught and swallowed).
+    * If an SSH connection drops.
+
+    This coroutine monitors the parents of a process and will kill the child
+    if any of its parents change.
+
+    Args:
+        proc:
+            The process to monitor and kill if needeed.
+        interval:
+            The polling interval to check the parent process tree in seconds.
+            If not provided, this will default to the environment variabble
+            "CYLC_PROC_POLL_INTERVAL" if set, else 60.
+
+    """
     gpa = get_proc_ancestors()
     # Allow customising the interval to allow tests to run faster:
-    interval = float(os.getenv('CYLC_PROC_POLL_INTERVAL', 60))
+    interval = interval or float(os.getenv('CYLC_PROC_POLL_INTERVAL', 60))
     while True:
-        sleep(interval)
+        await asyncio.sleep(interval)
         if proc.poll() is not None:
             break
         if get_proc_ancestors() != gpa:
-            sleep(1)
+            await asyncio.sleep(1)
             os.kill(proc.pid, signal.SIGTERM)
             break
 

--- a/cylc/flow/scripts/cat_log.py
+++ b/cylc/flow/scripts/cat_log.py
@@ -61,6 +61,7 @@ Examples:
   $ cylc cat-log foo//2020/bar -m f
 """
 
+import asyncio
 import os
 from contextlib import suppress
 from glob import glob
@@ -308,7 +309,7 @@ def view_log(
         proc = Popen(shlex.split(cmd), stdin=DEVNULL)  # nosec
         # * batchview command is user configurable
         with suppress(KeyboardInterrupt):
-            watch_and_kill(proc)
+            asyncio.run(watch_and_kill(proc))
         return proc.wait()
 
 

--- a/cylc/flow/scripts/profiler.py
+++ b/cylc/flow/scripts/profiler.py
@@ -20,6 +20,7 @@ Profiler which periodically polls cgroups to track
 the resource usage of jobs running on the node.
 """
 
+import asyncio
 import json
 import os
 import re
@@ -33,6 +34,7 @@ from dataclasses import dataclass
 
 from cylc.flow.exceptions import CylcProfilerError
 from cylc.flow.option_parsers import CylcOptionParser as COP
+from cylc.flow.remote import watch_and_kill
 from cylc.flow.task_message import record_messages
 from cylc.flow.terminal import cli_function
 
@@ -207,14 +209,14 @@ def get_cgroup_paths(location) -> Process:
             err, "Unable to determine cgroup version") from err
 
 
-def profile(_process: Process, delay, keep_looping=lambda: True):
+async def profile(_process: Process, delay, keep_looping=lambda: True):
     # The infinite loop that will constantly poll the cgroup
     # The lambda function is used to allow the loop to be stopped in unit tests
 
     while keep_looping():
         # Write cpu / memory usage data to disk
         # CPU_TIME = parse_cpu_file(process.cgroup_cpu_path, version)
-        time.sleep(delay)
+        await asyncio.sleep(delay)
 
 
 def get_option_parser() -> COP:
@@ -237,10 +239,10 @@ def get_option_parser() -> COP:
 @cli_function(get_option_parser)
 def main(_parser: COP, options) -> None:
     """CLI main."""
-    _main(options)
+    asyncio.run(_main(options))
 
 
-def _main(options) -> None:
+async def _main(options) -> None:
     # get cgroup information
     process = get_cgroup_paths(options.cgroup_location)
 
@@ -250,5 +252,12 @@ def _main(options) -> None:
     signal.signal(signal.SIGHUP, _stop_profiler)
     signal.signal(signal.SIGTERM, _stop_profiler)
 
-    # run profiler run
-    profile(process, options.delay)
+    # the profiler will run until one of these coroutines calls `sys.exit`:
+    await asyncio.gather(
+        # run the profiler itself
+        profile(process, options.delay),
+
+        # kill the profiler if its PPID changes
+        # (i.e, if the job exits before the profiler does)
+        watch_and_kill(os.getpid()),
+    )

--- a/tests/unit/scripts/test_profiler.py
+++ b/tests/unit/scripts/test_profiler.py
@@ -15,19 +15,25 @@
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 # Tests for functions contained in cylc.flow.scripts.profiler
-from cylc.flow.scripts.profiler import (parse_memory_file,
-                                        parse_cpu_file,
-                                        parse_memory_allocated,
-                                        get_cgroup_name,
-                                        get_cgroup_version,
-                                        get_cgroup_paths,
-                                        get_profiler_data,
-                                        stop_profiler,
-                                        profile,
-                                        Process)
-import pytest
+
 from unittest import mock
+
+import pytest
+
 from cylc.flow.exceptions import CylcProfilerError
+from cylc.flow.scripts.profiler import (
+    Process,
+    _main,
+    get_cgroup_name,
+    get_cgroup_paths,
+    get_cgroup_version,
+    get_profiler_data,
+    parse_cpu_file,
+    parse_memory_allocated,
+    parse_memory_file,
+    profile,
+    stop_profiler,
+)
 
 
 def test_stop_profiler(monkeypatch, tmpdir):
@@ -304,7 +310,7 @@ def test_get_cgroup_paths(mocker):
     assert "Unable to determine cgroup version" in str(excinfo.value)
 
 
-def test_profile_data(mocker):
+async def test_profile_data(mocker):
     # This test should run without error
     mocker.patch("cylc.flow.scripts.profiler.get_cgroup_name",
                  return_value='test_name')
@@ -319,7 +325,7 @@ def test_profile_data(mocker):
     mocker.patch("cylc.flow.scripts.profiler.parse_cpu_file",
                  return_value=2048)
     run_once = mock.Mock(side_effect=[True, False])
-    profile(process, 1, run_once)
+    await profile(process, 1, run_once)
 
 
 @pytest.fixture
@@ -331,7 +337,7 @@ def options(mocker):
     return opts
 
 
-def test_main(mocker, options):
+async def test_main(mocker, options):
     mock_get_cgroup_paths = mocker.patch(
         "cylc.flow.scripts.profiler.get_cgroup_paths"
     )
@@ -340,8 +346,7 @@ def test_main(mocker, options):
 
     mock_get_cgroup_paths.return_value = mocker.Mock()
 
-    from cylc.flow.scripts.profiler import _main
-    _main(options)
+    await _main(options)
 
     mock_get_cgroup_paths.assert_called_once_with("/fake/path")
     assert mock_signal.call_count == 3


### PR DESCRIPTION
During testing I found a bunch of orphaned `cylc profiler` processes lingering on my system.

I'm not quite sure how they accumulated, possibly the result of `kill` commands or something icky. Either way, we really need to make sure we don't litter.

* This commit protects against the scenario that the job script is unable to issue the kill signal to the profiler for whatever reason.
* The profiler will watch its own parent processes and terminate itself if any of its parents change (e.g, as the result of the job script exiting).

To test, try disabling the kill logic in the job script and ensure the profiler is cleaned up:

```diff
diff --git a/cylc/flow/etc/job.sh b/cylc/flow/etc/job.sh
index 16849e9f4..897c10401 100755
--- a/cylc/flow/etc/job.sh
+++ b/cylc/flow/etc/job.sh
@@ -200,9 +200,10 @@ cylc__set_return() {
 ###############################################################################
 # Save the data using cylc message and exit the profiler
 cylc__kill_profiler() {
-    if [[ -n "${profiler_pid:-}" ]] && ps -p "$profiler_pid" > /dev/null; then
-      kill -s SIGINT "${profiler_pid}" || true
-    fi
+    true
+    # if [[ -n "${profiler_pid:-}" ]] && ps -p "$profiler_pid" > /dev/null; then
+    #   kill -s SIGINT "${profiler_pid}" || true
+    # fi
 }
 
 ###############################################################################
```

(Automated testing is rather awkward since this requires patching the Bash script)